### PR TITLE
When deploying to heroku, error suggest that we run this terminal com…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.7-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.7-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.4.1)
     popper_js (2.9.3)
@@ -251,6 +253,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
…mand: bundle lock --add-platform x86_64-linux in order to deploy